### PR TITLE
Remove track number when enabled to fetchInfo from Genius

### DIFF
--- a/src/lib/NowPlayingContext.ts
+++ b/src/lib/NowPlayingContext.ts
@@ -97,6 +97,10 @@ class NowPlayingContext {
     return this.#pluginContext.coreCommand.sharedVars.get('language_code');
   }
 
+  getPluginSetting(type: string, plugin: string, setting: string): any {
+    return this.#pluginContext.coreCommand.executeOnPlugin(type, plugin, 'getConfigParam', setting);
+  }
+
   getErrorMessage(message: string, error: any, stack = true): string {
     let result = message;
     if (typeof error == 'object') {

--- a/src/lib/utils/Misc.ts
+++ b/src/lib/utils/Misc.ts
@@ -50,3 +50,11 @@ export function getVolumioBackgrounds() {
 export function rnd(min: number, max: number) {
   return Math.floor(Math.random() * (max - min) + min);
 }
+
+export function removeSongNumber(name: string) {
+  // Translates "8 - Yellow Dog" to "Yellow Dog" for good Match on Genius service.
+  const songNameRegex = /^(?:\d+\s*-\s*)([\w\d\s\p{L}.()-].+)$/u;
+  const matches = name.match(songNameRegex);
+  const newName = matches && matches?.length > 1 ? matches[1] : name;
+  return newName;
+}


### PR DESCRIPTION
Related to #11.

The idea is to check if the setting is enabled, if so then remove the track number from the title. 

Ex: For a song title "8 - Yellow Dog" the request to Genius will be "Yellow Dog" after removing the track number.