### PR TITLE
feat: "show clock" config option on idle screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"lodash": "^4.17.21",
 		"md5": "^2.3.0",
 		"node-cache": "^5.1.2",
-		"now-playing-common": "git+https://github.com/patrickkfkan/volumio-now-playing-common#v0.3.3",
+		"now-playing-common": "git+https://github.com/phts/NP-01_now-playing-common#b069223f7bfd40350e0e321cf8cb39f4c45b0fc0",
 		"semver": "^7.5.4",
 		"string-format": "^2.0.0",
 		"v-conf": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"lodash": "^4.17.21",
 		"md5": "^2.3.0",
 		"node-cache": "^5.1.2",
-		"now-playing-common": "git+https://github.com/phts/NP-01_now-playing-common#b069223f7bfd40350e0e321cf8cb39f4c45b0fc0",
+		"now-playing-common": "github:patrickkfkan/volumio-now-playing-common#v0.3.4",
 		"semver": "^7.5.4",
 		"string-format": "^2.0.0",
 		"v-conf": "^1.4.3",

--- a/src/UIConfig.json
+++ b/src/UIConfig.json
@@ -3370,6 +3370,7 @@
         "data": [
           "enabled",
           "waitTime",
+          "showClock",
           "showLocation",
           "showWeather",
           "mainAlignment",
@@ -3460,6 +3461,12 @@
           "doc": "TRANSLATE.NOW_PLAYING_DOC_IDLE_SCREEN_WAIT_TIME",
           "label": "TRANSLATE.NOW_PLAYING_WAIT_TIME",
           "value": 30
+        },
+        {
+          "id": "showClock",
+          "element": "switch",
+          "label": "TRANSLATE.NOW_PLAYING_SHOW_CLOCK",
+          "value": true
         },
         {
           "id": "showLocation",

--- a/src/i18n/strings_en.json
+++ b/src/i18n/strings_en.json
@@ -228,6 +228,7 @@
   "NOW_PLAYING_ALL_CLIENTS": "All clients",
   "NOW_PLAYING_DISABLED": "Disabled",
   "NOW_PLAYING_WAIT_TIME": "Wait Time (Seconds)",
+  "NOW_PLAYING_SHOW_CLOCK": "Show Clock",
   "NOW_PLAYING_SHOW_LOCATION": "Show Location (Uses Weather Info)",
   "NOW_PLAYING_SHOW_WEATHER": "Show Weather",
   "NOW_PLAYING_IDLE_SCREEN_MAIN_ALIGNMENT": "Main Alignment",

--- a/src/i18n/strings_es.json
+++ b/src/i18n/strings_es.json
@@ -206,6 +206,7 @@
   "NOW_PLAYING_ALL_CLIENTS": "Todos los clientes",
   "NOW_PLAYING_DISABLED": "Desactivado",
   "NOW_PLAYING_WAIT_TIME": "Tiempo de espera (Segundos)",
+  "NOW_PLAYING_SHOW_CLOCK": "Show Clock",
   "NOW_PLAYING_SHOW_LOCATION": "Mostrar Ubicación (Usa Información del Clima)",
   "NOW_PLAYING_SHOW_WEATHER": "Mostrar Clima",
   "NOW_PLAYING_IDLE_SCREEN_MAIN_ALIGNMENT": "Alineación Principal",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1085,6 +1085,7 @@ class ControllerNowPlaying {
         break;
     }
     idleScreenUIConf.content.waitTime.value = idleScreen.waitTime;
+    idleScreenUIConf.content.showClock.value = idleScreen.showClock;
     idleScreenUIConf.content.showLocation.value = idleScreen.showLocation;
     idleScreenUIConf.content.showWeather.value = idleScreen.showWeather;
     idleScreenUIConf.content.mainAlignment.value = {

--- a/src/lib/config/UIConfigSchema.ts
+++ b/src/lib/config/UIConfigSchema.ts
@@ -254,6 +254,7 @@ export type UIConfigSectionContentKeyOf<K extends UIConfigSectionKey> =
   K extends 'section_idle_view' ?
     'enabled' | 
     'waitTime' | 
+    'showClock' | 
     'showLocation' | 
     'showWeather' | 
     'mainAlignment' | 
@@ -596,6 +597,7 @@ export type UIConfigElementOf<K extends UIConfigSectionKey, C extends UIConfigSe
   K extends 'section_idle_view' ? (
     C extends 'enabled' ? UIConfigSelect<K> :
     C extends 'waitTime' ? UIConfigInput<K, 'number'> :
+    C extends 'showClock' ? UIConfigSwitch<K> :
     C extends 'showLocation' ? UIConfigSwitch<K> :
     C extends 'showWeather' ? UIConfigSwitch<K> :
     C extends 'mainAlignment' ? UIConfigSelect<K> :


### PR DESCRIPTION
## Feature

To be able to hide clock on idle screen and just to keep only pure image.

New "Show clock ON/OFF" option in the "Idle Screen" settings.

## TODO

1. Merge https://github.com/patrickkfkan/volumio-now-playing-common/pull/3 and bump new version
2. Install new version of `now-playing-common`
3. Merge https://github.com/patrickkfkan/volumio-now-playing-reactjs-client/pull/5
4. Build `volumio-now-playing-reactjs-client` into `src/app/client`
5. Build the app and commit

## Related MRs

- https://github.com/patrickkfkan/volumio-now-playing-reactjs-client/pull/5
- https://github.com/patrickkfkan/volumio-now-playing-common/pull/3

## Pics

![PXL_20250523_124956853](https://github.com/user-attachments/assets/ddfdcc0d-1e4e-48d3-93c7-5d8bb6a88edd)

![Screen Shot 2025-05-23 at 14 46 36-fullpage](https://github.com/user-attachments/assets/cee01622-a1ae-44f0-867a-10e97ba8cf96)
